### PR TITLE
Исправление заголовков ответа (фикс проксирования аудио)

### DIFF
--- a/deno/requests.js
+++ b/deno/requests.js
@@ -8,8 +8,11 @@ async function makeRequest(ctx, url, options) {
 
   ctx.response.status = response.status;
   ctx.response.body = response.body;
-  ctx.response.headers = response.headers;
-  
+
+  for (const [name, value] of response.headers) {
+    ctx.response.headers.append(name, value);
+  }
+
   ctx.response.headers.append("X-Yandex-Status", "success");
 }
 

--- a/deno/requests.js
+++ b/deno/requests.js
@@ -8,6 +8,11 @@ async function makeRequest(ctx, url, options) {
 
   ctx.response.status = response.status;
   ctx.response.body = response.body;
+
+  for (const [name, value] of response.headers) {
+    ctx.response.headers.append(name, value);
+  }
+
   ctx.response.headers.append("X-Yandex-Status", "success");
 }
 

--- a/deno/requests.js
+++ b/deno/requests.js
@@ -8,11 +8,8 @@ async function makeRequest(ctx, url, options) {
 
   ctx.response.status = response.status;
   ctx.response.body = response.body;
-
-  for (const [name, value] of response.headers) {
-    ctx.response.headers.append(name, value);
-  }
-
+  ctx.response.headers = response.headers;
+  
   ctx.response.headers.append("X-Yandex-Status", "success");
 }
 


### PR DESCRIPTION
Хром не может проматывать аудио, если не знает сколько байт содержит аудио.
То есть, если нету заголовка "Content-Length", перематывать он не будет. 😐